### PR TITLE
keeping the user signed in to the app even after refreshing it

### DIFF
--- a/sign-lingual-app-android/app/src/main/java/com/example/signlingual/BaseActivity.java
+++ b/sign-lingual-app-android/app/src/main/java/com/example/signlingual/BaseActivity.java
@@ -86,6 +86,7 @@ public class BaseActivity extends AppCompatActivity implements NavigationView.On
             preferences = getSharedPreferences("Credentials", MODE_PRIVATE);
             SharedPreferences.Editor editor = preferences.edit();
             editor.remove("userId");
+            editor.putBoolean("isLoggedIn", false);
             editor.apply();
             startActivity(intent);
         }

--- a/sign-lingual-app-android/app/src/main/java/com/example/signlingual/SignInActivity.java
+++ b/sign-lingual-app-android/app/src/main/java/com/example/signlingual/SignInActivity.java
@@ -75,6 +75,7 @@ public class SignInActivity extends BaseActivity {
                                 String userID = user.getUid();
                                 //store the userID in shared preferences
                                 SharedPreferences.Editor editor = sharedPreferences.edit();
+                                editor.putBoolean("isLoggedIn", true);
                                 editor.putString("userID", userID);
                                 editor.apply();
 
@@ -100,6 +101,12 @@ public class SignInActivity extends BaseActivity {
     public void onStart() {
         super.onStart();
         FirebaseUser currentUser = mAuth.getCurrentUser();
+        if(sharedPreferences.getBoolean("isLoggedIn", false)) {
+            Intent intent = new Intent(this, MainActivity.class);
+            startActivity(intent);
+            finish();
+            return;
+        }
         if(currentUser != null){
             reload();
         }


### PR DESCRIPTION
**Implementing persistent User Login when restarting the app**

**Description**

- Modified the SignInActivity to check SharedPreferences for a user's logged-in state upon app startup.

- Stored a boolean flag in SharedPreferences upon successful user sign-in.

- Ensured that users are redirected to MainActivity if they are already logged in.
